### PR TITLE
ATDA-4 Fix axios error

### DIFF
--- a/.agent/AGENT.md
+++ b/.agent/AGENT.md
@@ -16,7 +16,7 @@ This document configures how the agent should work on this codebase. Read it tog
 
 - **Consistency**: Any change to sync or storage must preserve the “sync token only after commit” guarantee. Do not update the token outside the transaction or before all entity writes/deletes.
 - **Data model**: Entity kinds (`Serie`, `Movie`, `Videogame`, `Book`, `Not_found`, `Sync_token`), keys (Todoist item id), and indexes are defined in PRD §4 and `index.yaml`. Long text fields are excluded from indexes.
-- **Integrations**: Todoist Sync API v9, OMDb, IGDB (Twitch OAuth), Open Library. Env vars and behavior are in PRD §5 and §8.1.
+- **Integrations**: Todoist API v1 (Sync endpoint; requests must be `application/x-www-form-urlencoded` — see `routes/apiCalls.js`), OMDb, IGDB (Twitch OAuth), Open Library. Env vars and behavior are in PRD §5 and §8.1.
 
 The agent must **know and use** this context when suggesting or implementing changes.
 
@@ -32,7 +32,7 @@ Before editing, the agent should locate and understand the relevant parts of the
 | Sync flow, Todoist → enrich → Datastore transaction, token update | `routes/update_database.js` |
 | Category routes, info endpoints, “any” (recommend) endpoints | `routes/series.js`, `routes/movies.js`, `routes/videogames.js`, `routes/books.js` |
 | Auth (login/logout, session) | `routes/auth.js` |
-| External API calls (OMDb, IGDB, Open Library) | `routes/apiCalls.js` |
+| External API calls (Todoist Sync, OMDb, IGDB, Open Library) | `routes/apiCalls.js` |
 | Datastore queries and helpers | `routes/queries.js` |
 | Views and layout | `views/` (`.hbs`), `views/partials/` (carousel, footer, category scripts) |
 | Indexes | `index.yaml` |
@@ -97,7 +97,7 @@ When modifying the frontend (Handlebars, CSS, Bootstrap, Slick, `public/`):
 - **No sensitive data in docs**: Do not store secrets, API keys, real project IDs, passwords, or deployment-specific URLs in any `.md` file or README. Use placeholders and refer to env/config.
 - **Main documentation**: `docs/README.md` — product requirements (PRD), data model, sync flow, routes, env.
 - **Future changes**: `docs/PRD-desired-changes.md` — agreed next steps (e.g. refresh button, configurable Todoist IDs).
-- **Sync**: One run at startup in `app.js`; full flow in `routes/update_database.js`; token in same transaction as entity writes.
+- **Sync**: One run at startup in `app.js`; full flow in `routes/update_database.js`; token in same transaction as entity writes. Todoist Sync uses API v1 (`/api/v1/sync`) with **form-urlencoded** body (see `routes/apiCalls.js`).
 - **Auth**: Session (express-session), 15 min cookie; `APPLICATION_LOGIN_USER` and bcrypt `APPLICATION_LOGIN_SECRET`.
 
 Use this file as the default agent behavior for this project.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 node_modules/
 recommender-279710-3de9c6e2e6e5.json
+test.js

--- a/docs/DEPLOYMENT-GCP.md
+++ b/docs/DEPLOYMENT-GCP.md
@@ -1,0 +1,101 @@
+# Google Cloud / App Engine deployment checklist
+
+This doc helps avoid 503s and auth failures on Google App Engine (e.g. `POST /auth/login`).
+
+---
+
+## 1. Environment variables are not loaded from `.env` in production
+
+- **Locally:** `dotenv` loads variables from a `.env` file.
+- **On App Engine:** The deployed app does **not** use your local `.env` (it is excluded via `.gcloudignore`). The only way the app gets variables is:
+  - **`app.yaml` → `env_variables`**, or
+  - **Google Cloud Console** (App Engine → Settings → Environment variables), or
+  - **Secret Manager** (with code changes to read secrets at runtime).
+
+If you never set `SESSION_SECRET`, `APPLICATION_LOGIN_USER`, or `APPLICATION_LOGIN_SECRET` for the App Engine service, they will be **undefined** in production. That leads to:
+
+- `express-session` throwing (e.g. "secret required") when handling login.
+- `bcrypt.compare` throwing if the hash is undefined, or the app returning "Login is not configured" (after the recent auth hardening).
+
+**Fix:** Define all required environment variables for the App Engine service.
+
+---
+
+## 2. Where to set environment variables
+
+### Option A – `app.yaml` (simple, but secrets in config)
+
+Uncomment the `env_variables` block in `app.yaml` and set real values. **Do not commit real secrets to git.** Use a private branch, or use Option B for secrets.
+
+```yaml
+env_variables:
+  SESSION_SECRET: "a-long-random-string"
+  APPLICATION_LOGIN_USER: "your-username"
+  APPLICATION_LOGIN_SECRET: "$2b$10$..."   # bcrypt hash only
+  TODOIST_API_KEY: "..."
+  OMDb_API_KEY: "..."
+  IGDB_API_CLIENT_ID: "..."
+  IGDB_API_SECRET: "..."
+```
+
+Then deploy: `gcloud app deploy`.
+
+### Option B – Cloud Console (no secrets in repo)
+
+1. Open [Google Cloud Console](https://console.cloud.google.com/) → your project.
+2. **App Engine** → **Settings** (or **Configuration** for the service).
+3. Add **Environment variables** for the same keys as above.
+4. Redeploy the app so new instances pick them up.
+
+### Option C – Secret Manager (recommended for secrets)
+
+Store secrets in Secret Manager and either:
+
+- Inject them at deploy time (e.g. Cloud Build reads secrets and writes `env_variables` or a generated config), or
+- Have the Node app fetch them at startup (requires code changes).
+
+---
+
+## 3. Required variables for auth and stability
+
+| Variable | Required for | Notes |
+|----------|----------------|-------|
+| `SESSION_SECRET` | Session cookie signing | Must be set or `express-session` can throw and cause 503. |
+| `APPLICATION_LOGIN_USER` | Login | Username for the app. |
+| `APPLICATION_LOGIN_SECRET` | Login | **Must be a bcrypt hash** of the password (e.g. `node -e "console.log(require('bcrypt').hashSync('your-password', 10))"`). Not the plain password. |
+
+Other variables (Todoist, OMDb, IGDB) are needed for sync and enrichment; missing ones can cause sync or API errors but not necessarily the login 503.
+
+---
+
+## 4. Credentials and permissions
+
+- **Datastore:** App Engine’s default service account has access to the project’s Datastore. No extra config if the app runs in the same project.
+- **No extra “auth” flags** are required for the app’s own login; the 503 is from missing env vars or uncaught errors, not from IAM or OAuth for your Express app.
+- If you use **Secret Manager**, the App Engine default service account needs `roles/secretmanager.secretAccessor` (or equivalent) on the relevant secrets.
+
+---
+
+## 5. Quick checks after deploy
+
+1. **Confirm env vars for the running version**  
+   `gcloud app versions describe VERSION_ID --service=default` and check `env_variables` (if set in `app.yaml`).
+
+2. **Logs**  
+   In Cloud Console → Logging, filter by resource type “App Engine” and look for:
+   - `"Auth config missing: APPLICATION_LOGIN_USER or APPLICATION_LOGIN_SECRET not set"` → set those env vars.
+   - `"Login bcrypt error"` or `"secret required"` → fix `APPLICATION_LOGIN_SECRET` (must be bcrypt hash) or `SESSION_SECRET`.
+
+3. **Retry login**  
+   After setting variables, redeploy or wait for new instances; then try `POST /auth/login` again.
+
+---
+
+## 6. Summary
+
+| Issue | Cause | Fix |
+|-------|--------|-----|
+| 503 on `/auth/login` | Missing `SESSION_SECRET` or auth env vars; uncaught errors | Set `SESSION_SECRET`, `APPLICATION_LOGIN_USER`, `APPLICATION_LOGIN_SECRET` in `env_variables` or Console. |
+| “Login is not configured” | `APPLICATION_LOGIN_USER` or `APPLICATION_LOGIN_SECRET` not set in GCP | Add them for the App Engine service. |
+| “Username and password not correct” | Wrong credentials or `APPLICATION_LOGIN_SECRET` is plain password | Use bcrypt hash for `APPLICATION_LOGIN_SECRET`. |
+| .env not used in production | `.env` is not deployed (and should not be) | Use `app.yaml` `env_variables` or Cloud Console / Secret Manager. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ This document describes the product requirements for a **media backlog and recom
 | Aspect | Description |
 |--------|-------------|
 | **Deployment** | Google App Engine (Node.js 22, standard environment) |
-| **Data source** | Todoist (Sync API v9), via project folders per category |
+| **Data source** | Todoist (API v1 Sync endpoint), via project folders per category |
 | **Storage** | Google Cloud Datastore |
 | **Enrichment** | OMDb (movies/series), IGDB + Twitch OAuth (videogames), Open Library (books) |
 | **Frontend** | Express + Handlebars, Bootstrap, Slick carousels, session-based auth |
@@ -149,12 +149,13 @@ Entity keys in Datastore use the **Todoist item id** (`parseInt(item.id)`) so th
 
 ### 5.1 Todoist
 
-- **API:** Sync API v9 (`https://api.todoist.com/sync/v9/sync`).
+- **API:** Todoist API v1 — Sync endpoint (`https://api.todoist.com/api/v1/sync`). Reference: [developer.todoist.com/api/v1](https://developer.todoist.com/api/v1/).
+- **Request format:** Sync requests must be sent as **`application/x-www-form-urlencoded`** (not JSON). Implemented in `routes/apiCalls.js` via `URLSearchParams` and `Content-Type: application/x-www-form-urlencoded`.
 - **Auth:** Bearer token (`TODOIST_API_KEY`).
 - **Behavior:**  
   - First run: `sync_token: '*'` for full sync.  
   - Subsequent runs: stored `Sync_token` for incremental sync.  
-- **Resource:** `resource_types: '["items"]'`.
+- **Resource:** `resource_types: '["items"]'` (JSON-encoded array in the form body).
 - **Data used:** `item.id`, `item.project_id`, `item.content`, `item.checked`, `item.completed_at`, `item.labels` (tags), `item.is_deleted`.
 
 ### 5.2 OMDb (Movies & Series)
@@ -285,3 +286,4 @@ Sample provided in `.env_sample` (key placeholders only; no real secrets).
 | Version | Date       | Changes |
 |---------|------------|---------|
 | 1.0     | Feb 2025   | Initial PRD from repository review. |
+| 1.1     | Feb 2026   | Todoist: document API v1 Sync endpoint, correct URL, and form-urlencoded request format (fix for 400 Bad Request). |

--- a/routes/apiCalls.js
+++ b/routes/apiCalls.js
@@ -2,17 +2,20 @@ const axios = require('axios');
 
 async function getDataTodoist(sync_token) {
     try {
-            return axios.post('https://api.todoist.com/api/v1/sync', {
-                sync_token: sync_token !== 'undefined' ? sync_token : '*',
-                resource_types: '["items"]'
-            },
-            {
+            // Todoist Sync API requires application/x-www-form-urlencoded (see https://developer.todoist.com/api/v1/)
+            const params = new URLSearchParams();
+            params.append('sync_token', (sync_token === undefined || sync_token === 'undefined') ? '*' : String(sync_token));
+            params.append('resource_types', '["items"]');
+
+            return axios.post('https://api.todoist.com/api/v1/sync', params.toString(), {
                 headers: {
-                    Authorization: `Bearer ${process.env.TODOIST_API_KEY}`
+                    'Authorization': `Bearer ${process.env.TODOIST_API_KEY}`,
+                    'Content-Type': 'application/x-www-form-urlencoded'
                 }
             });
     } catch (error) {
             console.error(`Error in apiCalls / getDataTodoist: \n${error}`);
+            throw error;
     }
 }
 


### PR DESCRIPTION
fix(todoist): use form-urlencoded for Sync API and update docs to API v1

- Send Todoist /api/v1/sync body as application/x-www-form-urlencoded
  (was JSON, caused 400). Use URLSearchParams in routes/apiCalls.js.
- Propagate getDataTodoist errors so updateDatabase sees failures.
- Docs: README §5.1 and AGENT.md now reference API v1 and request format.
- PRD-desired-changes: add optional follow-up for Todoist string IDs (§6).